### PR TITLE
Find-AVSignature

### DIFF
--- a/AntivirusBypass/Find-AVSignature.ps1
+++ b/AntivirusBypass/Find-AVSignature.ps1
@@ -34,7 +34,11 @@ Specifies the path to the binary you want tested.
 .PARAMETER OutPath
 
 Optionally specifies the directory to write the binaries to.
-    
+
+.PARAMETER BufferLen
+
+Specifies the length of the file read buffer .  Defaults to 64KB.  
+
 .PARAMETER Force
 
 Forces the script to continue without confirmation.    
@@ -61,7 +65,8 @@ http://heapoverflow.com/f0rums/project.php?issueid=34&filter=changes&page=2
 
     [CmdletBinding()] Param(
         [Parameter(Mandatory = $True)]
-        [Int32]
+        [ValidateRange(0,4294967295)]
+		[UInt32]
         $StartByte,
 
         [Parameter(Mandatory = $True)]
@@ -69,7 +74,8 @@ http://heapoverflow.com/f0rums/project.php?issueid=34&filter=changes&page=2
         $EndByte,
 
         [Parameter(Mandatory = $True)]
-        [Int32]
+        [ValidateRange(0,4294967295)]
+		[UInt32]
         $Interval,
 
         [String]
@@ -79,7 +85,9 @@ http://heapoverflow.com/f0rums/project.php?issueid=34&filter=changes&page=2
         [String]
         $OutPath = ($pwd),
 		
-		[int]
+		
+		[ValidateRange(1,2097152)]
+		[UInt32]
 		$BufferLen = 65536,
 		
         [Switch] $Force
@@ -143,7 +151,7 @@ http://heapoverflow.com/f0rums/project.php?issueid=34&filter=changes&page=2
 			Write-Verbose "Byte 0 -> $($SplitByte)"
 			
 			#Reset ReadStream to beginning of file
-			$ReadStream.Seek(0, [System.IO.SeekOrigin]::Begin)
+			$ReadStream.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
 			
 			#Build a new FileStream for Writing
 			[String] $outfile = Join-Path $OutPath "$($FileName)_$($SplitByte).bin"


### PR DESCRIPTION
First and Foremost, Great Project.  Very impressed with what you have done so far.

I needed to use the Find-AVSignature for something I'm doing and decided to take a look at improving the performance.  I wanted to let you take a look at what I did and see if you could use it as well.

I changed the output design to use the [System.IO.FileStream] .NET class with a large buffer (64kb default).  This helps with performance and memory utilization, especially when handling large files.  The Stream will read and store up to 64KB at a time from the OS file handle, even if we request less.   However, the OS and disks may also cache the entire file in the background until the file handle is released, speeding up the subsequent read access requests automatically.

Test Performance Run seem to show significant gains, especially when using large files (1mb+)  

Source File Size / Time to Build 10 files:
1MB: 11959.0728ms -> 225.3825ms 
10MB: 141314.4916ms -> 615.282ms
## Log

2013-05-02 01:06:45 [Info]: (test.ps1)  
2013-05-02 01:06:45 [Info]: (test.ps1)  ----------------
2013-05-02 01:06:45 [Info]: (test.ps1)  Testing 10K file
2013-05-02 01:06:45 [Info]: (test.ps1)  ----------------
2013-05-02 01:06:45 [Info]: (test.ps1)  OLD: Find-AVSignature -StartByte 1000 -EndByte 10000 -Interval 1000 -Path D:\temp\AVSig\10k.bin -OutPath D:\temp\AVSig\output\b -Verbose -Force
2013-05-02 01:06:45 [Info]: (test.ps1)  142.9064ms
2013-05-02 01:06:45 [Info]: (test.ps1)  NEW: Find-AVSignatureb -StartByte 1000 -EndByte 10000 -Interval 1000 -Path D:\temp\AVSig\10k.bin -OutPath D:\temp\AVSig\output\b -Verbose -Force
2013-05-02 01:06:45 [Info]: (test.ps1)  74.7294ms
2013-05-02 01:06:45 [Info]: (test.ps1)  OLD: Find-AVSignature -StartByte 6800 -EndByte 6900 -Interval 10 -Path D:\temp\AVSig\10k.bin -OutPath D:\temp\AVSig\output\b -Verbose -Force
2013-05-02 01:06:46 [Info]: (test.ps1)  177.5741ms
2013-05-02 01:06:46 [Info]: (test.ps1)  NEW: Find-AVSignatureb -StartByte 6800 -EndByte 6900 -Interval 10 -Path D:\temp\AVSig\10k.bin -OutPath D:\temp\AVSig\output\b -Verbose -Force
2013-05-02 01:06:46 [Info]: (test.ps1)  92.6656ms
2013-05-02 01:06:46 [Info]: (test.ps1)                  

2013-05-02 01:06:46 [Info]: (test.ps1)  ----------------
2013-05-02 01:06:46 [Info]: (test.ps1)  Testing 1MB file
2013-05-02 01:06:46 [Info]: (test.ps1)  ----------------
2013-05-02 01:06:46 [Info]: (test.ps1)  OLD: Find-AVSignature -StartByte 600000 -EndByte 690000 -Interval 10000 -Path D:\temp\AVSig\1mb.bin -OutPath D:\temp\AVSig\output\a -Verbose -Force
2013-05-02 01:06:58 [Info]: (test.ps1)  11959.0728ms
2013-05-02 01:06:58 [Info]: (test.ps1)  NEW: Find-AVSignatureb -StartByte 600000 -EndByte 690000 -Interval 10000 -Path D:\temp\AVSig\1mb.bin -OutPath D:\temp\AVSig\output\b -Verbose -Force
2013-05-02 01:06:58 [Info]: (test.ps1)  225.3825ms
2013-05-02 01:06:58 [Info]: (test.ps1)  OLD: Find-AVSignature -StartByte 600000 -EndByte 690000 -Interval 10000 -Path D:\temp\AVSig\1mb.bin -OutPath D:\temp\AVSig\output\a -Verbose -Force
2013-05-02 01:07:10 [Info]: (test.ps1)  11794.5296ms
2013-05-02 01:07:10 [Info]: (test.ps1)  NEW: Find-AVSignatureb -StartByte 600000 -EndByte 690000 -Interval 10000 -Path D:\temp\AVSig\1mb.bin -OutPath D:\temp\AVSig\output\b -Verbose -Force
2013-05-02 01:07:10 [Info]: (test.ps1)  225.1076ms
2013-05-02 01:07:10 [Info]: (test.ps1)  

2013-05-02 01:07:10 [Info]: (test.ps1)  ----------------
2013-05-02 01:07:10 [Info]: (test.ps1)  Testing 10MB file
2013-05-02 01:07:10 [Info]: (test.ps1)  ----------------
2013-05-02 01:07:10 [Info]: (test.ps1)  OLD: Find-AVSignature -StartByte 6800000 -EndByte 6900000 -Interval 100000 -Path D:\temp\AVSig\10mb.bin -OutPath D:\temp\AVSig -Verbose -Force
2013-05-02 01:09:31 [Info]: (test.ps1)  141314.4916ms
2013-05-02 01:09:31 [Info]: (test.ps1)  NEW: Find-AVSignatureb -StartByte 6800000 -EndByte 6900000 -Interval 100000 -Path D:\temp\AVSig\10mb.bin -OutPath D:\temp\AVSig 

-Verbose -Force
2013-05-02 01:09:32 [Info]: (test.ps1)  615.282ms
2013-05-02 01:09:32 [Info]: (test.ps1)  Clearing Test Files

I also changed the $EndBytes validation logic to set it to a valid value rather simply than throw an error.  I was running into some errors with known good values. 
