### PR TITLE
Call to DllMain when unloading reflective DLL

### DIFF
--- a/CodeExecution/Invoke-ReflectivePEInjection.ps1
+++ b/CodeExecution/Invoke-ReflectivePEInjection.ps1
@@ -2620,6 +2620,15 @@ Blog on modifying mimikatz for reflective loading: http://clymb3r.wordpress.com/
 				    $ImportDescriptorPtr = Add-SignedIntAsUnsigned ($ImportDescriptorPtr) ([System.Runtime.InteropServices.Marshal]::SizeOf($Win32Types.IMAGE_IMPORT_DESCRIPTOR))
 			    }
 		    }
+			
+			#Call DllMain with process detach
+			Write-Verbose "Calling dllmain so the DLL knows it is being unloaded"
+			$DllMainPtr = Add-SignedIntAsUnsigned ($PEInfo.PEHandle) ($PEInfo.IMAGE_NT_HEADERS.OptionalHeader.AddressOfEntryPoint)
+			$DllMainDelegate = Get-DelegateType @([IntPtr], [UInt32], [IntPtr]) ([Bool])
+			$DllMain = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($DllMainPtr, $DllMainDelegate)
+			
+			$DllMain.Invoke($PEInfo.PEHandle, 0, [IntPtr]::Zero) | Out-Null
+		
 		
 		    $Success = $Win32Functions.VirtualFree.Invoke($PEHandle, [UInt64]0, $Win32Constants.MEM_RELEASE)
 		    if ($Success -eq $false)


### PR DESCRIPTION
Prior to this fix, DllMain with the ProessDetach flag was not called
when unloading the reflectively loaded DLL. This was causing very weird
crashes in the Invoke-NinjaCopy script which is built on this script.
This should fix the crash.
