### PR TITLE
Fixes bug on 'Count' property of the $XMLFiles object

### DIFF
--- a/Exfiltration/Get-GPPPassword.ps1
+++ b/Exfiltration/Get-GPPPassword.ps1
@@ -201,7 +201,7 @@ function Get-GPPPassword {
     
         if ( -not $XMlFiles ) {throw 'No preference files found.'}
 
-        Write-Verbose "Found $($XMLFiles.Count) files that could contain passwords."
+        Write-Verbose "Found $($XMLFiles | Measure-Object | select -ExpandProperty Count) files that could contain passwords."
     
         foreach ($File in $XMLFiles) {
             $Result = (Get-GppInnerFields $File.Fullname)


### PR DESCRIPTION
Error message when attempting to run:

PS C:> Get-GPPPassword
Get-GPPPassword : Property 'Count' cannot be found on this object. Make sure that it exists.
At line:1 char:16
- Get-GPPPassword <<<<
  - CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
  - FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Get-GPPPassword
