### PR TITLE
Bugfix: Resolving ordinals in remote dll injection

### DIFF
--- a/CodeExecution/Invoke-ReflectivePEInjection.ps1
+++ b/CodeExecution/Invoke-ReflectivePEInjection.ps1
@@ -33,7 +33,7 @@ Author: Joe Bialek, Twitter: @JosephBialek
 License: BSD 3-Clause
 Required Dependencies: None
 Optional Dependencies: None
-Version: 1.2
+Version: 1.3
 
 .DESCRIPTION
 
@@ -1547,7 +1547,7 @@ $RemoteScriptBlock = {
 		{
 			Throw "Unable to allocate memory in the remote process for shellcode"
 		}
-		
+		[UIntPtr]$NumBytesWritten = [UIntPtr]::Zero
 		$Success = $Win32Functions.WriteProcessMemory.Invoke($RemoteProcHandle, $RSCAddr, $SCPSMemOriginal, [UIntPtr][UInt64]$SCLength, [Ref]$NumBytesWritten)
 		if (($Success -eq $false) -or ([UInt64]$NumBytesWritten -ne [UInt64]$SCLength))
 		{


### PR DESCRIPTION
Thanks to sixdub for finding and fixing a bug when resolving functions
by ordinal in remote processes.