### PR TITLE
UserPersistenceOption -> ScheduledTaskAtLogon Fix

### DIFF
--- a/Persistence/Persistence.psm1
+++ b/Persistence/Persistence.psm1
@@ -651,9 +651,9 @@ Get-WmiObject __FilterToConsumerBinding -Namespace root\subscription | Where-Obj
             {
                 'AtLogon'
                 {
-                    $ElevatedTrigger = "schtasks /Create /RU system /SC ONLOGON /TN Updater /TR "
+                    $UserTrigger = "schtasks /Create /SC ONLOGON /TN Updater /TR "
                 }
-                
+
                 'Daily'
                 {
                     $UserTrigger = "schtasks /Create /SC DAILY /ST $($UserPersistenceOption.Time.ToString('HH:mm:ss')) /TN Updater /TR "

--- a/Persistence/Persistence.psm1
+++ b/Persistence/Persistence.psm1
@@ -254,6 +254,7 @@ function New-UserPersistenceOption
         [Parameter( ParameterSetName = 'ScheduledTaskDaily', Mandatory = $True )]
         [Parameter( ParameterSetName = 'ScheduledTaskHourly', Mandatory = $True )]
         [Parameter( ParameterSetName = 'ScheduledTaskOnIdle', Mandatory = $True )]
+        [Parameter( ParameterSetName = 'ScheduledTaskAtLogon', Mandatory = $True )]
         [Switch]
         $ScheduledTask,
 
@@ -278,6 +279,7 @@ function New-UserPersistenceOption
         $OnIdle,
 
         [Parameter( ParameterSetName = 'Registry', Mandatory = $True )]
+        [Parameter( ParameterSetName = 'ScheduledTaskAtLogon', Mandatory = $True )]
         [Switch]
         $AtLogon
     )
@@ -647,6 +649,11 @@ Get-WmiObject __FilterToConsumerBinding -Namespace root\subscription | Where-Obj
 
             switch ($UserPersistenceOption.Trigger)
             {
+                'AtLogon'
+                {
+                    $ElevatedTrigger = "schtasks /Create /RU system /SC ONLOGON /TN Updater /TR "
+                }
+                
                 'Daily'
                 {
                     $UserTrigger = "schtasks /Create /SC DAILY /ST $($UserPersistenceOption.Time.ToString('HH:mm:ss')) /TN Updater /TR "


### PR DESCRIPTION
Attempting to leverage the `Add-Persistence` module with the following parameter combination would result in an `AmbiguousParameterSet` error:

`$UserOptions = New-UserPersistenceOption -ScheduledTask -AtLogon`

This was due to missing parameter/cmdlet bindings within the `New-UserPersistenceOption` function as well as missing switch-case logic within the `Add-Persistence` function.