### PR TITLE
Added WDS backup file check

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -3786,7 +3786,7 @@ function Get-WSDSetupInfo {
     $ErrorActionPreference = "SilentlyContinue"
 
     $SearchLocations = @(   "c:\windows\panther\setupinfo.bak",
-                            (Join-Path $Env:WinDir "\Panther\setupinfo.bak"),
+                            (Join-Path $Env:WinDir "\Panther\setupinfo.bak")
                         )
 
     # test the existence of the file in the above paths


### PR DESCRIPTION
This file contains the cleartext domain, username, and password of the account used to authenticate to Windows Setup during installation.

http://blog.win-fu.com/2017/08/stored-passwords-found-all-over-place.html