### PR TITLE
GetProcAddress has a new additional signature = ambiguous error

### DIFF
--- a/CodeExecution/Invoke-Shellcode.ps1
+++ b/CodeExecution/Invoke-Shellcode.ps1
@@ -131,7 +131,7 @@ Warning: This script has no way to validate that your shellcode is 32 vs. 64-bit
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress' , [reflection.bindingflags] "Public,Static", $null, [System.Reflection.CallingConventions]::Any, @((New-Object System.Runtime.InteropServices.HandleRef).GetType(), [string]), $null)
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr


### PR DESCRIPTION
Cobalt got the same "ambiguous" powershell issue, since they use your code:
https://blog.cobaltstrike.com/2018/05/24/powershell-shellcode-injection-on-win-10-v1803/

However, this genious fix from @CG-root for Invoke-Mimikatz solves the issue for Invoke-Shellcode as well:
https://github.com/mitre/caldera/issues/38#issuecomment-396055260